### PR TITLE
procServ unix socket fallback

### DIFF
--- a/iocBoot/iocrsfsx/runProcServ.sh
+++ b/iocBoot/iocrsfsx/runProcServ.sh
@@ -7,8 +7,9 @@ set +u
 . ./parseCMDOpts.sh "$@"
 
 # Use defaults if not set
+UNIX_SOCKET=""
 if [ -z "${DEVICE_TELNET_PORT}" ]; then
-   DEVICE_TELNET_PORT="20000"
+    UNIX_SOCKET="true"
 fi
 
 if [ -z "${DEVICE_TYPE}" ]; then
@@ -18,4 +19,8 @@ fi
 set -u
 
 # Run run*.sh scripts with procServ
-/usr/local/bin/procServ -f -n RS_${DEVICE_TYPE} -i ^C^D ${DEVICE_TELNET_PORT} ./runRSFSx.sh "$@"
+if [ "${UNIX_SOCKET}" ]; then
+    /usr/local/bin/procServ -f -n RS_${DEVICE_TYPE} -i ^C^D unix:./procserv.sock ./runRSFSx.sh "$@"
+else
+    /usr/local/bin/procServ -f -n RS_${DEVICE_TYPE} -i ^C^D ${DEVICE_TELNET_PORT} ./runRSFSx.sh "$@"
+fi


### PR DESCRIPTION
Instead of using the default port value, the runProcServ.sh script will use UNIX sockets.